### PR TITLE
Add iproute2 to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 LABEL maintainer="team@appwrite.io"
 
 RUN apt-get update && \
-    apt-get install -y exim4-daemon-light && \
+    apt-get install -y iproute2 exim4-daemon-light && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     find /var/log -type f | while read f; do echo -ne '' > $f; done;


### PR DESCRIPTION
- added iproute2 to Dockerfile

The command [here](https://github.com/appwrite/docker-smtp/blob/master/entrypoint.sh#L29) needs **iproute2** to run.