### PR TITLE
Use Alpine Linux in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,3 +15,4 @@ EXPOSE 25
 ENTRYPOINT ["/bin/entrypoint.sh"]
 
 CMD ["exim", "-bd", "-q15m", "-v"]
+ 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,8 @@
-FROM ubuntu:18.04
+FROM alpine:latest
 
 LABEL maintainer="team@appwrite.io"
 
-RUN apt-get update && \
-    apt-get install -y iproute2 exim4-daemon-light && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-    find /var/log -type f | while read f; do echo -ne '' > $f; done;
+RUN apk add --no-cache exim iproute2
 
 COPY entrypoint.sh /bin/
 COPY set-exim4-update-conf /bin/


### PR DESCRIPTION
Update Dockerfile to use Alpine Linux instead of Ubuntu.

See the difference in disk usage in the screenshot below.

![Screenshot 2020-09-26 at 19 36 03](https://user-images.githubusercontent.com/23658248/94346830-a6648300-002f-11eb-9f57-cbefb002c6e0.png)
